### PR TITLE
Update rest-layout-service.ts

### DIFF
--- a/packages/sitecore-jss/src/layout/rest-layout-service.ts
+++ b/packages/sitecore-jss/src/layout/rest-layout-service.ts
@@ -215,12 +215,17 @@ export class RestLayoutService extends LayoutServiceBase {
   protected setupReqHeaders(req: IncomingMessage) {
     return (reqConfig: AxiosRequestConfig) => {
       debug.layout('performing request header passing');
+
+      const xForwardedFor = req.headers['x-forwarded-for'];
+      const remoteAddress = req.socket?.remoteAddress;
+
       reqConfig.headers.common = {
         ...reqConfig.headers.common,
         ...(req.headers.cookie && { cookie: req.headers.cookie }),
         ...(req.headers.referer && { referer: req.headers.referer }),
         ...(req.headers['user-agent'] && { 'user-agent': req.headers['user-agent'] }),
-        ...(req.connection.remoteAddress && { 'X-Forwarded-For': req.connection.remoteAddress }),
+        ...(xForwardedFor && { 'X-Forwarded-For': xForwardedFor }),
+        ...(remoteAddress && !xForwardedFor && { 'X-Forwarded-For': remoteAddress }),
       };
       return reqConfig;
     };


### PR DESCRIPTION
Should resolve GeoIP / tracking issues with using REST Layout Service.

- [x] This PR follows the [Contribution Guide](https://github.com/Sitecore/jss/blob/dev/CONTRIBUTING.md)
- [ ] Changelog updated

## Description / Motivation
When the REST Layout service is called from the Next application, when running containerized (in stead of Vercel or other SWA environments) the x-forwarded-ip header should be forwarded in stead of the socket remote address which can be belong to a load balancer. Also replaced connection for socket as its deprecated since v16. 

## Testing Details
<!--- Please describe how you tested your changes. -->
<!--- When applicable, include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Unit Test Added
- [x] Manual Test/Other (Please elaborate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
